### PR TITLE
Replace magic with puremagic

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,37 +142,14 @@ a tag from the list below:
 | all                 | All Langfun features.                    |
 | vertexai            | VertexAI access.                         |
 | mime                | All MIME supports.                       |
-| mime-auto           | Automatic MIME type detection.           |
 | mime-pil            | Image support for PIL.                   |
 | ui                  | UI enhancements                          |
 
 For example, to install a nightly build that includes VertexAI access, full
 modality support, and UI enhancements, use:
+
 ```
 pip install langfun[vertexai,mime,ui] --pre
-```
-
-### Solving import issue with `libmagic`
-
-Langfun utilizes `libmagic` for automatic MIME type detection to support
-multi-modal functionalities. However, `pip install libmagic` may not work
-out-of-the-box on all operation systems, sometimes leading to an
-`'ImportError: failed to find libmagic.'` error after Langfun installation.
-
-If you encounter this error, you will need to follow the recommendations below
-to fix the installation of `libmagic` library.
-
-#### OSX
-
-```
-conda install conda-forge::libmagic
-```
-
-#### Windows:
-```
-pip install python-magic
-pip uninstall python-magic-bin
-pip install python-magic-bin
 ```
 
 *Disclaimer: this is not an officially supported Google product.*

--- a/langfun/core/modalities/audio_test.py
+++ b/langfun/core/modalities/audio_test.py
@@ -34,8 +34,8 @@ class AudioTest(unittest.TestCase):
 
   def test_audio_content(self):
     audio = audio_lib.Audio.from_bytes(content_bytes)
-    self.assertEqual(audio.mime_type, 'audio/x-wav')
-    self.assertEqual(audio.audio_format, 'x-wav')
+    self.assertIn(audio.mime_type, ('audio/wave', 'audio/x-wav'))
+    self.assertIn(audio.audio_format, ('wave', 'x-wav'))
     self.assertEqual(audio.to_bytes(), content_bytes)
 
   def test_bad_audio(self):
@@ -50,8 +50,8 @@ class AudioFileTest(unittest.TestCase):
     audio = audio_lib.Audio.from_uri('http://mock/web/a.wav')
     with mock.patch('requests.get') as mock_requests_get:
       mock_requests_get.side_effect = mock_request
-      self.assertEqual(audio.audio_format, 'x-wav')
-      self.assertEqual(audio.mime_type, 'audio/x-wav')
+      self.assertIn(audio.audio_format, ('wave', 'x-wav'))
+      self.assertIn(audio.mime_type, ('audio/wave', 'audio/x-wav'))
       self.assertEqual(
           audio._raw_html(),
           '<audio controls> <source src="http://mock/web/a.wav"> </audio>',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,14 @@
-pyglove>=0.4.5.dev202409110000
 jinja2>=3.1.2
+puremagic>=1.20
+pyglove>=0.4.5.dev202507140812
 requests>=2.31.0
-
-# extras:ui
-termcolor==1.1.0
-tqdm>=4.64.1
 
 # extras:vertexai
 google-auth>=2.16.0
 
-# extras:mime-auto
-python-magic>=0.4.27
 # extras:mime-pil
 pillow>=10.0.0
+
+# extras:ui
+termcolor==1.1.0
+tqdm>=4.64.1


### PR DESCRIPTION
1) For better Mac/Windows support
2) For faster MIME detection based on file header. (Python native implementation)
3) Install puremagic by default.