### PR TITLE
Fix: Enforce sandbox evaluation in PythonFunction.implementation

### DIFF
--- a/langfun/core/coding/python/generation.py
+++ b/langfun/core/coding/python/generation.py
@@ -205,7 +205,7 @@ class PythonFunction(pg.Object):
   @functools.cached_property
   def implementation(self) -> Callable[..., Any]:
     """Returns the function implementation based on source code."""
-    return execution.run(self.source)
+    return execution.run(self.source, sandbox=True)
 
   def __call__(
       self,


### PR DESCRIPTION
## Security Fix: Unsandboxed Code Execution in PythonFunction

### Summary
`PythonFunction.implementation` was calling `execution.run(self.source)` 
without explicit sandbox parameter, allowing arbitrary code execution 
in the main process.

### Fix
Added explicit `sandbox=True` parameter to `execution.run()` call.

### Security Impact
Without this fix, any untrusted input processed by PythonFunction 
(LLM output, MCP server responses) could execute arbitrary OS commands 
in the host process — including file access, network calls, and 
environment variable theft.

### Note
A detailed vulnerability report including PoC has been submitted to 
Google OSS VRP. PoC details are withheld pending merge to avoid 
premature disclosure.

Related: [Google OSS VRP submission - pending]